### PR TITLE
Disabled installation of pry-rails

### DIFF
--- a/build-rails
+++ b/build-rails
@@ -105,7 +105,7 @@ cd $DIR_APP && bash mod_app.sh '04-01' $TOGGLE_OUTLINE
 cd $DIR_APP && bash mod_app.sh '04-02' $TOGGLE_OUTLINE
 cd $DIR_APP && bash mod_app.sh '04-03' $TOGGLE_OUTLINE
 cd $DIR_APP && bash mod_app.sh '04-04' $TOGGLE_OUTLINE
-cd $DIR_APP && bash mod_app.sh '04-05' $TOGGLE_OUTLINE
+# cd $DIR_APP && bash mod_app.sh '04-05' $TOGGLE_OUTLINE
 cd $DIR_APP && bash mod_app.sh '04-06' $TOGGLE_OUTLINE
 
 cd $DIR_APP && bash mod_app.sh '05-01' $TOGGLE_OUTLINE


### PR DESCRIPTION
The "rails generate" command was failing when pry-rails was installed but has no problems without pry-rails.  The likely culprit is the upstream method_source gem, which released the new version 1.0.0 today.